### PR TITLE
Check collaborator permissions to ensure they have triage or above rights

### DIFF
--- a/src/graphql/maintainers.gql
+++ b/src/graphql/maintainers.gql
@@ -1,8 +1,9 @@
 query ($cursor: String $owner: String! $repo: String!) {
     repository(name:$repo owner:$owner) {
-        collaborators(after:$cursor first:100) {
+        collaborators(after:$cursor first:100 affiliation:DIRECT) {
             nodes {
                 login
+                permission
             }
             pageInfo {
                 hasNextPage

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,10 @@ export const getGraphql = memoize((name: string): string => {
 export const getCollaborators = memoize(async (octokit: PaginatedOctokit, owner: string, repo: string) => {
     const query = getGraphql("maintainers.gql");
     const resp2 = await octokit.graphql.paginate(query, { owner: owner, repo: repo });
-    return resp2.repository.collaborators.nodes.map((i: any) => i.login);
+    const allowedPermissions = ['TRIAGE', 'WRITE', 'MAINTAIN', 'ADMIN'];
+    return resp2.repository.collaborators.nodes
+        .filter((i: any) => allowedPermissions.includes(i.permission))
+        .map((i: any) => i.login);
 }, {
     // By default, all JS memoize functions only memoize on the first arg wtf?
     cacheKey: args => JSON.stringify(args)


### PR DESCRIPTION
This starts to address #13, in that it makes explicit what roles a "maintainer" has. We may want to track only engagement by people with repo write access, or just with repo triage access, or both.