### PR TITLE
Fix typo for unhandled statusRollupCheck

### DIFF
--- a/src/fields/cistatus.ts
+++ b/src/fields/cistatus.ts
@@ -9,7 +9,7 @@ export const getCIStatus: typeof REQUIRED_FIELDS["CI Status"]["getValue"] = asyn
             return "Tests Failing"
         } else {
             console.log('found unhandled rollup state');
-            console.log(pr.statusCheck.state)
+            console.log(pr.statusCheckRollup.state)
             console.log(pr.url);
             return null;
         }


### PR DESCRIPTION
This works around an error we see occasionally:

```
Syncing project fields...
found unhandled rollup state
file:///home/runner/work/pr-triage-board-bot/pr-triage-board-bot/dist/src/fields/cistatus.js:9
            console.log(pr.statusCheck.state);
                                       ^

TypeError: Cannot read properties of undefined (reading 'state')
    at Object.getCIStatus [as getValue] (file:///home/runner/work/pr-triage-board-bot/pr-triage-board-bot/dist/src/fields/cistatus.js:9:40)
    at main (file:///home/runner/work/pr-triage-board-bot/pr-triage-board-bot/dist/src/main.js:94:48)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Command.<anonymous> (file:///home/runner/work/pr-triage-board-bot/pr-triage-board-bot/dist/src/main.js:111:5)
```
(see https://github.com/yuvipanda/pr-triage-board-bot/actions/runs/17681440003/job/50256320976, for example)