### PR TITLE
Attempt fix for sporadic 502 errors on listing PRs by having a smaller page size

### DIFF
--- a/src/graphql/openprs.gql
+++ b/src/graphql/openprs.gql
@@ -1,5 +1,5 @@
 query ($cursor: String, $searchQuery: String!) {
- search(type:ISSUE first:50 query:$searchQuery after:$cursor){
+ search(type:ISSUE first:30 query:$searchQuery after:$cursor){
   nodes {
     ... on PullRequest {
       id,


### PR DESCRIPTION
When I searched for why we might be getting 502 errors, it seems timeouts may be a cause. Here we only request 30 prs at a time instead of 50 to try to cut down on the time for each page of PRs returned