### PR TITLE
Reproduce errors occuring in external repos

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -12,7 +12,6 @@ jobs:
   jupyterhub:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - name: Run JupyterHub PR Triage Bot
         uses: ./
         with:
@@ -25,7 +24,6 @@ jobs:
   jupyterlab:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - name: Run JupyterLab PR Triage Bot
         uses: ./
         with:


### PR DESCRIPTION
This PR should reproduce the [errors occurring in third-party repos](https://github.com/geojupyter/jupytergis/actions/runs/17754946814/job/50456273746) by eliminating the benefit conferred by checking out this repo's code before running the action.

Partially addresses concerns raised in #37 , but does not resolve it. That'll take a bit more doing.