### PR TITLE
Add permission to get members of teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ from 2i2c for context:
    b. Disable webhooks as we will not be using them.
 
    c. Permissions:
-    - i. "Repository Permissions" -> "Metadata" -> "Read-only" (to get list of collaborators for a repo)
-    - ii. "Organization Permissions" -> "Projects" -> "Read and write" (to manage the GitHub project)
+    - "Repository Permissions" -> "Metadata" -> "Read-only" (to get list of collaborators for a repo)
+    - "Organization Permissions" -> "Members" -> "Read-only" (to get members of collaborating teams)
+    - "Organization Permissions" -> "Projects" -> "Read and write" (to manage the GitHub project)
 
    d. Where can this GitHub App be installed? Set to `Only on this account`
 


### PR DESCRIPTION
We noticed that authorkind was incorrect for some PRs. For example, https://github.com/jupyterlab/jupyterlab/pull/17893 had authorkind of Seasoned Contributor, but the PR author has triage permissions. Adding the org member read-only permission solved the issue - the getCollaborators seems to now be returning the full list of people with triage/maintain/admin access.

However, I don't see exactly why it solved the issue. At first I thought the extra permission would allow listing members of teams, so would get all the collaborators. However, the list of collaborators returned before the permission update doesn't seem to follow a pattern. For example, in jlab, each team with repo triage/maintain/admin access has people both in and not in the before list of collaborators, and only teams are collaborating on the repo.