### PR TITLE
Don't count folks with triage permissions as 'maintainers'

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,8 @@ export const getGraphql = memoize((name: string): string => {
 export const getCollaborators = memoize(async (octokit: PaginatedOctokit, owner: string, repo: string) => {
     const query = getGraphql("maintainers.gql");
     const resp2 = await octokit.graphql.paginate(query, { owner: owner, repo: repo });
-    const allowedPermissions = ['TRIAGE', 'WRITE', 'MAINTAIN', 'ADMIN'];
+    // Intentionally don't count TRIAGE permissions, as they can't merge PRs
+    const allowedPermissions = ['WRITE', 'MAINTAIN', 'ADMIN'];
     return resp2.repository.collaborators.edges
         .filter((edge: any) => allowedPermissions.includes(edge.permission))
         .map((edge: any) => edge.node.login);


### PR DESCRIPTION
'Maintainer' is a super loaded word, but I believe that since we operate on *pull requests*, it makes sense to treat folks who can merge PRs as 'maintainers'

Ref https://github.com/jupyter/pr-triage-board-bot/issues/13